### PR TITLE
update deprecated :erlang.now call

### DIFF
--- a/web/models/letters.ex
+++ b/web/models/letters.ex
@@ -1,17 +1,17 @@
 defmodule WordScram.Letters do
 
   def get_letter do
-    :random.seed(:erlang.now)
+    :random.seed(:erlang.timestamp)
      Enum.random(Enum.to_list(97..122))
   end
 
   def get_common_letter do
-    :random.seed(:erlang.now)
+    :random.seed(:erlang.timestamp)
      Enum.random('aeioust')
   end
 
   def get_random_letter do
-    :random.seed(:erlang.now)
+    :random.seed(:erlang.timestamp)
     random = Enum.random([0,1,2])
     if random == 2 do
       get_common_letter
@@ -21,7 +21,7 @@ defmodule WordScram.Letters do
   end
 
   def generate_letters do
-    :random.seed(:erlang.now)
+    :random.seed(:erlang.timestamp)
 
     Enum.to_list(0..9)
     |> Enum.map(fn i -> get_random_letter end)


### PR DESCRIPTION
Prior to this commit random letter generation was using `:erlang.now/0`,
which as of Erlang 18 is deprecated. The commit updates to
`:erlang.timestamp/0` which retains the same return signature of a three
element tuple but does not suffer the underlying issues as
`:erlang.now/0`.

For further detail, see
http://erlang.org/doc/apps/erts/time_correction.html
